### PR TITLE
Add configuration file for terminfo

### DIFF
--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,0 +1,1 @@
+term.cfg

--- a/config/term.cfg
+++ b/config/term.cfg
@@ -1,0 +1,1 @@
+term="xterm-256color"

--- a/zsh/term.zsh
+++ b/zsh/term.zsh
@@ -1,19 +1,31 @@
-# Use 256 Colour xterm if term allows
-if [ -e /usr/share/terminfo/t/tmux-256color ]; then
-    export TERM='tmux-256color'
-else
-    # Try to download the terminfo
-    echo "Did not find tmux-256color. Need sudo to install..."
-    sudo curl https://mikopits.github.io/public/tmux-256color -o /usr/share/terminfo/t/tmux-256color
+# Read from the terminal config
+source $HOME/.pshu/config/term.cfg
+
+if [ $term == "tmux-256color" ]; then
+    # Use 256 Colour xterm if term allows
     if [ -e /usr/share/terminfo/t/tmux-256color ]; then
         export TERM='tmux-256color'
     else
-        # Failed to get the terminfo, fall back to xterm
-        if [ -e /usr/share/terminfo/x/xterm-256color ]; then
-            export TERM='xterm-256color'
+        # Try to download the terminfo
+        echo "Did not find tmux-256color. Need sudo to install..."
+        sudo curl https://mikopits.github.io/public/tmux-256color -o /usr/share/terminfo/t/tmux-256color
+        if [ -e /usr/share/terminfo/t/tmux-256color ]; then
+            export TERM='tmux-256color'
         else
-            export TERM='xterm-color'
+            # Failed to get the terminfo, fall back to xterm
+            if [ -e /usr/share/terminfo/x/xterm-256color ]; then
+                export TERM='xterm-256color'
+            else
+                export TERM='xterm-color'
+            fi
         fi
+    fi
+else
+    # Default to xterm
+    if [ -e /usr/share/terminfo/x/xterm-256color ]; then
+        export TERM='xterm-256color'
+    else
+        export TERM='xterm-color'
     fi
 fi
 


### PR DESCRIPTION
Can't assume that the environment will be friendly to tmux-256color so default to xterm-256color unless otherwise specified in the config file.