### PR TITLE
Saner defaults to pshu.cfg and force add base16-shell to submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "zsh/base16-shell"]
-    path = zsh/base16-shell
-    url = https://github.com/chriskempson/base16-shell
+	path = zsh/base16-shell
+	url = https://github.com/chriskempson/base16-shell
 [submodule "vim/bundle/vundle"]
     path = vim/bundle/vundle
     url = https://github.com/VundleVim/Vundle.vim

--- a/pshu.cfg
+++ b/pshu.cfg
@@ -9,13 +9,13 @@ base16_theme=tomorrow-night
 prompt=pure
 
 # Start an xserver on login.
-startx_on_login=1
+startx_on_login=0
 
 # Start tmux session on shell start.
 tmux_on_login=1
 
 # Are you using the i3 window manager?
-i3wm=1
+i3wm=0
 
 # Print how long it takes to load zsh (debugging)
 print_launch_time=0


### PR DESCRIPTION
Should not default to starting xserver on init. base16-shell submodule would not clone due to being .gitignored